### PR TITLE
Use default root CAs for SSL connections

### DIFF
--- a/irc/connection.go
+++ b/irc/connection.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"net"
 	"crypto/tls"
+	"crypto/rand"
 	"fmt"
 	"strings"
 	"time"
@@ -100,15 +101,12 @@ func (conn *Conn) Connect(host string, ssl bool, pass string) os.Error {
 		}
 	}
 
-	var sock net.Conn;
-	var err os.Error;
-	if ssl {
-		sock, err = tls.Dial("tcp", "", host)
-	} else {
-		sock, err = net.Dial("tcp", "", host)
-	}
+	sock, err := net.Dial("tcp", "", host)
 	if err != nil {
 		return err
+	}
+	if ssl {
+		sock = tls.Client(sock, &tls.Config{Rand: rand.Reader, Time: time.Nanoseconds})
 	}
 
 	conn.Host = host
@@ -121,7 +119,6 @@ func (conn *Conn) Connect(host string, ssl bool, pass string) os.Error {
 	go conn.send()
 	go conn.recv()
 
-	// see getStringMsg() in commands.go for what this does
 	if pass != "" {
 		conn.Pass(pass)
 	}

--- a/rbot.conf.example
+++ b/rbot.conf.example
@@ -2,7 +2,7 @@
 server: irc.rizon.net
 nick: rbot
 user: rbot
-ssl: false
+ssl: true
 trigger: !
 
 [#raylu]


### PR DESCRIPTION
I cherry-picked your SSL support into rbot and was able to connect to irc.freenode.net:7000 but not irc.rizon.net:6697. Using this fixes "local error: bad certificate".
