### PR TITLE
Add support for servers that don't use : properly

### DIFF
--- a/irc/connection.go
+++ b/irc/connection.go
@@ -217,10 +217,14 @@ func (conn *Conn) recv() {
 		if len(args) > 1 {
 			line.Text = args[1]
 		}
-		args = strings.Split(args[0], " ", -1)
+		args = strings.Fields(args[0])
 		line.Cmd = strings.ToUpper(args[0])
 		if len(args) > 1 {
 			line.Args = args[1:len(args)]
+			// some servers (Gamesurge) don't use : properly
+			if line.Text == "" {
+				line.Text = args[1]
+			}
 		}
 		conn.in <- line
 	}


### PR DESCRIPTION
I had some trouble joining channels on Gamesurge. This fixes it, but I'm not sure if it doesn't break other servers (it still works fine on Rizon, but I haven't tested it much).

Basically, Gamesurge sends:
:nick!user@host JOIN #channel

when it should be sending
:nick!user@host JOIN :#channel
