### PR TITLE
Set a timeout so that Conn.Err closes when the connection is lost

### DIFF
--- a/client/connection.go
+++ b/client/connection.go
@@ -140,6 +140,7 @@ func (conn *Conn) Connect(host string, pass ...string) os.Error {
 	conn.io = bufio.NewReadWriter(
 		bufio.NewReader(conn.sock),
 		bufio.NewWriter(conn.sock))
+	conn.sock.SetTimeout(300000000000) // 5 minutes
 	go conn.send()
 	go conn.recv()
 


### PR DESCRIPTION
Otherwise, it's impossible to detect when the connection is dead. There should be a PING within 5 minutes anyway.
