### PR TITLE
Use the internal event handling for initial pass/user/nick messages.

### DIFF
--- a/client.go
+++ b/client.go
@@ -1,11 +1,11 @@
 package main
 
 import (
-	irc "github.com/fluffle/goirc/client"
+	"bufio"
 	"flag"
 	"fmt"
+	irc "github.com/fluffle/goirc/client"
 	"os"
-	"bufio"
 	"strings"
 )
 
@@ -36,6 +36,8 @@ func main() {
 			if err != nil {
 				// wha?, maybe ctrl-D...
 				close(in)
+				reallyquit = true
+				c.Quit("")
 				break
 			}
 			// no point in sending empty lines down the channel


### PR DESCRIPTION
This leaves me feeling calm that there are no special cases for the init process.
