### PR TITLE
state/tracker_test: remove undefined init

### DIFF
--- a/state/tracker_test.go
+++ b/state/tracker_test.go
@@ -1,15 +1,6 @@
 package state
 
-import (
-	"github.com/fluffle/goirc/logging"
-	"testing"
-)
-
-func init() {
-	// This is probably a dirty hack...
-	logging.InitFromFlags()
-	logging.SetLogLevel(logging.LogFatal)
-}
+import "testing"
 
 func TestSTNewTracker(t *testing.T) {
 	st := NewTracker("mynick")


### PR DESCRIPTION
$ go test github.com/fluffle/goirc/state
# github.com/fluffle/goirc/state

src/github.com/fluffle/goirc/state/tracker_test.go:10: undefined: logging.InitFromFlags
src/github.com/fluffle/goirc/state/tracker_test.go:11: undefined: logging.SetLogLevel
src/github.com/fluffle/goirc/state/tracker_test.go:11: undefined: logging.LogFatal
FAIL    github.com/fluffle/goirc/state [build failed]

The two logging calls https://github.com/fluffle/goirc/blob/master/state/tracker_test.go#L10

```
    logging.InitFromFlags()
    logging.SetLogLevel(logging.LogFatal)
```

are undefined in referenced goirc/logging package https://github.com/fluffle/goirc/blob/master/logging/logging.go
Removing so test works.
