### PR TITLE
client/mocknetconn_test: minor fix found by go vet

### DIFF
--- a/client/mocknetconn_test.go
+++ b/client/mocknetconn_test.go
@@ -130,11 +130,11 @@ func (m *mockNetConn) Closed() bool {
 }
 
 func (m *mockNetConn) LocalAddr() net.Addr {
-	return &net.IPAddr{net.IPv4(127, 0, 0, 1), ""}
+	return &net.IPAddr{IP: net.IPv4(127, 0, 0, 1)}
 }
 
 func (m *mockNetConn) RemoteAddr() net.Addr {
-	return &net.IPAddr{net.IPv4(127, 0, 0, 1), ""}
+	return &net.IPAddr{IP: net.IPv4(127, 0, 0, 1)}
 }
 
 func (m *mockNetConn) SetDeadline(t time.Time) error {


### PR DESCRIPTION
net.IPAddr composite literal uses unkeyed fields
