### PR TITLE
Make parseLine public by renaming it to ParseLine

### DIFF
--- a/client/connection.go
+++ b/client/connection.go
@@ -282,7 +282,7 @@ func (conn *Conn) recv() {
 		s = strings.Trim(s, "\r\n")
 		logging.Debug("<- %s", s)
 
-		if line := parseLine(s); line != nil {
+		if line := ParseLine(s); line != nil {
 			line.Time = time.Now()
 			conn.in <- line
 		} else {

--- a/client/connection_test.go
+++ b/client/connection_test.go
@@ -241,7 +241,7 @@ func TestRecv(t *testing.T) {
 	}
 
 	// Test that recv does something useful with a line it can't parse
-	// (not that there are many, parseLine is forgiving).
+	// (not that there are many, ParseLine is forgiving).
 	s.nc.Send(":textwithnospaces")
 	if l := reader(); l != nil {
 		t.Errorf("Bad line still caused receive on input channel.")
@@ -342,7 +342,7 @@ func TestRunLoop(t *testing.T) {
 		h002.call()
 	})
 
-	l1 := parseLine(":irc.server.org 001 test :First test line.")
+	l1 := ParseLine(":irc.server.org 001 test :First test line.")
 	c.in <- l1
 	h001.assertNotCalled("001 handler called before runLoop started.")
 
@@ -357,7 +357,7 @@ func TestRunLoop(t *testing.T) {
 
 	// Send another line, just to be sure :-)
 	h002.assertNotCalled("002 handler called before expected.")
-	l2 := parseLine(":irc.server.org 002 test :Second test line.")
+	l2 := ParseLine(":irc.server.org 002 test :Second test line.")
 	c.in <- l2
 	h002.assertWasCalled("002 handler not called while runLoop started.")
 

--- a/client/dispatch_test.go
+++ b/client/dispatch_test.go
@@ -196,6 +196,6 @@ func TestPanicRecovery(t *testing.T) {
 	c.HandleFunc(PRIVMSG, func(conn *Conn, line *Line) {
 		panic("panic!")
 	})
-	c.in <- parseLine(":nick!user@host.com PRIVMSG #channel :OH NO PIGEONS")
+	c.in <- ParseLine(":nick!user@host.com PRIVMSG #channel :OH NO PIGEONS")
 	recovered.assertWasCalled("Failed to recover panic!")
 }

--- a/client/line.go
+++ b/client/line.go
@@ -78,8 +78,8 @@ func (line *Line) Public() bool {
 }
 
 
-// parseLine() creates a Line from an incoming message from the IRC server.
-func parseLine(s string) *Line {
+// ParseLine() creates a Line from an incoming message from the IRC server.
+func ParseLine(s string) *Line {
 	line := &Line{Raw: s}
 	if s[0] == ':' {
 		// remove a source and parse it


### PR DESCRIPTION
As the `parseLine` function is useful for other projects this pull request makes it public and available for reuse.

The better approach would be to split out part of the client into a utility package, but that's too rigorous for now.
