### PR TITLE
client/connection: keep information in disconnected event, revert #43

### DIFF
--- a/client/connection.go
+++ b/client/connection.go
@@ -403,9 +403,11 @@ func (conn *Conn) shutdown() {
 	conn.sock.Close()
 	close(conn.die)
 	conn.wg.Wait()
+	// Dispatch after closing connection but before reinit
+	// so event handlers can still access state information.
+	conn.dispatch(&Line{Cmd: DISCONNECTED, Time: time.Now()})
 	// reinit datastructures ready for next connection
 	conn.initialise()
-	conn.dispatch(&Line{Cmd: DISCONNECTED, Time: time.Now()})
 }
 
 // Dumps a load of information about the current state of the connection to a


### PR DESCRIPTION
Revert of https://github.com/fluffle/goirc/commit/3fdd17a2b88b167b0a9ae6d219375bc47cc91f04 of #43.
Context: https://github.com/StalkR/goircbot/issues/9

It's important to keep information on the current connection before dispatching the disconnected event, so that event receivers can make informed decisions about the disconnection, such as saving the current list of channels.

The original problem encountered by @sztanpet is how to reconnect the bot from the event handler. As replied by @fluffle, don't reconnect at this point, instead send the information back to the main loop with a channel. For examples, see sp0rkle (https://github.com/fluffle/sp0rkle/blob/master/bot/serverset.go#L35) and goircbot (https://github.com/StalkR/goircbot/blob/master/bot/bot.go#L104).
