### PR TITLE
client/connection: conn.Me(): do not override cfg.Me or it is lost for next reconnect

### DIFF
--- a/client/connection.go
+++ b/client/connection.go
@@ -172,7 +172,7 @@ func (conn *Conn) Me() *state.Nick {
 	conn.mu.RLock()
 	defer conn.mu.RUnlock()
 	if conn.st != nil {
-		conn.cfg.Me = conn.st.Me()
+		return conn.st.Me()
 	}
 	return conn.cfg.Me
 }


### PR DESCRIPTION
When we disconnect:
1) shutdown() calls initialise() which wipes the state: https://github.com/fluffle/goirc/blob/master/client/connection.go#L214
2) Me() always takes it from the state: https://github.com/fluffle/goirc/blob/master/client/connection.go#L174
So in the end we've lost Me.Nick, Me.Ident, Me.Name which are needed for register: https://github.com/fluffle/goirc/blob/master/client%2Fhandlers.go#L39

This manifests as:
```
I0401 01:21:48.701247   32292 connection.go:248] irc.Connect(): Connecting to irc.stalkr.net:6697 with SSL.
I0401 01:21:49.715255   32292 connection.go:384] -> NICK godev
I0401 01:21:49.715401   32292 connection.go:384] -> USER  12 * :
I0401 01:21:49.715663   32292 connection.go:321] <- :irc.stalkr.net NOTICE AUTH :*** Looking up your hostname...
I0401 01:21:49.715679   32292 connection.go:321] <- :irc.stalkr.net NOTICE AUTH :*** Found your hostname (cached)
I0401 01:21:49.755733   32292 connection.go:321] <- PING :BF0EB246
I0401 01:21:49.755759   32292 connection.go:321] <- :irc.stalkr.net 461 godev USER :Not enough parameters
I0401 01:21:49.755906   32292 connection.go:384] -> PONG :BF0EB246
```