### PR TITLE
Change "gomock" repository URL

### DIFF
--- a/client/connection_test.go
+++ b/client/connection_test.go
@@ -1,8 +1,8 @@
 package client
 
 import (
-	"code.google.com/p/gomock/gomock"
 	"github.com/fluffle/goirc/state"
+	"github.com/golang/mock/gomock"
 	"strings"
 	"testing"
 	"time"

--- a/client/handlers_test.go
+++ b/client/handlers_test.go
@@ -1,8 +1,8 @@
 package client
 
 import (
-	"code.google.com/p/gomock/gomock"
 	"github.com/fluffle/goirc/state"
+	"github.com/golang/mock/gomock"
 	"testing"
 	"time"
 )

--- a/state/mock_tracker.go
+++ b/state/mock_tracker.go
@@ -4,7 +4,7 @@
 package state
 
 import (
-	gomock "code.google.com/p/gomock/gomock"
+	gomock "github.com/golang/mock/gomock"
 )
 
 // Mock of Tracker interface


### PR DESCRIPTION
It seems like gomock moved from code.google.com to github.com

This made travis fail on a project of mine. And if you create a new GOPATH in /tmp dir, goirc doesn't compile.