### PR TITLE
Fixed a typo in Readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ the messages from the IRC server, so you have to handle e.g. "332" for
 
 The vast majority of handlers implemented within the framework deal with state
 tracking of all nicks in any channels that the client is also present in. These
-handers are in `client/state_handlers.go`. State tracking is optional, disabled
+handlers are in `client/state_handlers.go`. State tracking is optional, disabled
 by default, and can be enabled and disabled by calling `EnableStateTracking()`
 and `DisableStateTracking()` respectively. Doing this while connected to an IRC
 server will probably result in an inconsistent state and a lot of warnings to


### PR DESCRIPTION
Just noticed a typo, thought I'd fix that right up. s/hander/handler