### PR TITLE
Add variadic Privmsg functions

### DIFF
--- a/client/commands.go
+++ b/client/commands.go
@@ -1,6 +1,9 @@
 package client
 
-import "strings"
+import (
+	"fmt"
+	"strings"
+)
 
 const (
 	REGISTER     = "REGISTER"
@@ -73,7 +76,7 @@ func splitMessage(msg string, splitLen int) (msgs []string) {
 		if idx < 0 {
 			idx = splitLen - 3
 		}
-		msgs = append(msgs, msg[:idx] + "...")
+		msgs = append(msgs, msg[:idx]+"...")
 		msg = msg[idx:]
 	}
 	return append(msgs, msg)
@@ -151,11 +154,32 @@ func (conn *Conn) Who(nick string) { conn.Raw(WHO + " " + nick) }
 // Privmsg sends a PRIVMSG to the target nick or channel t.
 // If msg is longer than Config.SplitLen characters, multiple PRIVMSGs
 // will be sent to the target containing sequential parts of msg.
-//     PRIVMSG t :msg
+// PRIVMSG t :msg
 func (conn *Conn) Privmsg(t, msg string) {
+	prefix := PRIVMSG + " " + t + " :"
 	for _, s := range splitMessage(msg, conn.cfg.SplitLen) {
-		conn.Raw(PRIVMSG + " " + t + " :" + s)
+		conn.Raw(prefix + s)
 	}
+}
+
+// Privmsgln is the variadic version of Privmsg that formats the message
+// that is sent to the target nick or channel t using the
+// fmt.Sprintln function.
+// Note: Privmsgln doesn't add the '\n' character at the end of the message.
+func (conn *Conn) Privmsgln(t string, a ...interface{}) {
+	msg := fmt.Sprintln(a...)
+	// trimming the new-line character added by the fmt.Sprintln function,
+	// since it's irrelevant.
+	msg = msg[:len(msg)-1]
+	conn.Privmsg(t, msg)
+}
+
+// Privmsgf is the variadic version of Privmsg that formats the message
+// that is sent to the target nick or channel t using the
+// fmt.Sprintf function.
+func (conn *Conn) Privmsgf(t, format string, a ...interface{}) {
+	msg := fmt.Sprintf(format, a...)
+	conn.Privmsg(t, msg)
 }
 
 // Notice sends a NOTICE to the target nick or channel t.

--- a/client/commands_test.go
+++ b/client/commands_test.go
@@ -118,10 +118,38 @@ func TestClientCommands(t *testing.T) {
 	c.Privmsg("#foo", "bar")
 	s.nc.Expect("PRIVMSG #foo :bar")
 
+	c.Privmsgln("#foo", "bar")
+	s.nc.Expect("PRIVMSG #foo :bar")
+
+	c.Privmsgf("#foo", "say %s", "foo")
+	s.nc.Expect("PRIVMSG #foo :say foo")
+
+	c.Privmsgln("#foo", "bar", 1, 3.54, []int{24, 36})
+	s.nc.Expect("PRIVMSG #foo :bar 1 3.54 [24 36]")
+
+	c.Privmsgf("#foo", "user %d is at %s", 2, "home")
+	s.nc.Expect("PRIVMSG #foo :user 2 is at home")
+
 	//                 0123456789012345678901234567890123
 	c.Privmsg("#foo", "foo bar baz blorp. woo woobly woo.")
 	s.nc.Expect("PRIVMSG #foo :foo bar baz blorp. ...")
 	s.nc.Expect("PRIVMSG #foo :woo woobly woo.")
+
+	c.Privmsgln("#foo", "foo bar baz blorp. woo woobly woo.")
+	s.nc.Expect("PRIVMSG #foo :foo bar baz blorp. ...")
+	s.nc.Expect("PRIVMSG #foo :woo woobly woo.")
+
+	c.Privmsgf("#foo", "%s %s", "foo bar baz blorp.", "woo woobly woo.")
+	s.nc.Expect("PRIVMSG #foo :foo bar baz blorp. ...")
+	s.nc.Expect("PRIVMSG #foo :woo woobly woo.")
+
+	c.Privmsgln("#foo", "foo bar", 3.54, "blorp.", "woo", "woobly", []int{1, 2})
+	s.nc.Expect("PRIVMSG #foo :foo bar 3.54 blorp. ...")
+	s.nc.Expect("PRIVMSG #foo :woo woobly [1 2]")
+
+	c.Privmsgf("#foo", "%s %.2f %s %s %s %v", "foo bar", 3.54, "blorp.", "woo", "woobly", []int{1, 2})
+	s.nc.Expect("PRIVMSG #foo :foo bar 3.54 blorp. ...")
+	s.nc.Expect("PRIVMSG #foo :woo woobly [1 2]")
 
 	c.Notice("somebody", "something")
 	s.nc.Expect("NOTICE somebody :something")


### PR DESCRIPTION
PrivmsgFmt is the variadic version of the Privmsg function.
It formats the message from a list of arguments before sending it
using the Privmsg function.

For example, the following sends "golang is # 1 IMHO" to #go-nuts:

    c.PrivmsgFmt("#go-nuts", "golang is #", 1, " IMHO")

**Note**: this is a small change, which I find handy.


### EDIT

`Privmsgln` and `Privmsgf` are variadic versions of the `Privmsg` function.
They format a message according to `fmt.Sprintln` and `fmt.Sprintf`
respectively and send it using `Privmsg`.

Note: Although the `Privmsgln` function's name infers that a new-line
character is added at the end of the message, it does not do that.

For example, the following send "golang is # 1 IMHO" to #go-nuts:

    c.Privmsgln("#go-nuts", "golang is #", 1, " IMHO")
    c.Privmsgf("#go-nots", "%s %d %s", "golang is #", 1, "IMHO")