### PR TITLE
Add IRCv3 tag parsing and CAP command

### DIFF
--- a/client/commands.go
+++ b/client/commands.go
@@ -293,10 +293,10 @@ func (conn *Conn) Pong(message string) { conn.Raw(PONG + " :" + message) }
 
 // Cap sends a CAP command to the server.
 //     CAP capability
-func (conn *Conn) Cap(subcommmand string, messages ...string) {
-	if len(messages) == 0 {
+func (conn *Conn) Cap(subcommmand string, message ...string) {
+	if len(message) == 0 {
 		conn.Raw(CAP + " " + subcommmand)
 	} else {
-		conn.Raw(CAP + " " + subcommmand + " :" + strings.Join(messages, " "))
+		conn.Raw(CAP + " " + subcommmand + " :" + message[0])
 	}
 }

--- a/client/commands.go
+++ b/client/commands.go
@@ -294,10 +294,10 @@ func (conn *Conn) Pong(message string) { conn.Raw(PONG + " :" + message) }
 // Cap sends a CAP command to the server.
 //     CAP subcommand
 //     CAP subcommand :message
-func (conn *Conn) Cap(subcommmand string, message ...string) {
-	if len(message) == 0 {
+func (conn *Conn) Cap(subcommmand string, capabilities ...string) {
+	if len(capabilities) == 0 {
 		conn.Raw(CAP + " " + subcommmand)
 	} else {
-		conn.Raw(CAP + " " + subcommmand + " :" + message[0])
+		conn.Raw(CAP + " " + subcommmand + " :" + strings.Join(capabilities, " "))
 	}
 }

--- a/client/commands.go
+++ b/client/commands.go
@@ -292,7 +292,8 @@ func (conn *Conn) Ping(message string) { conn.Raw(PING + " :" + message) }
 func (conn *Conn) Pong(message string) { conn.Raw(PONG + " :" + message) }
 
 // Cap sends a CAP command to the server.
-//     CAP capability
+//     CAP subcommand
+//     CAP subcommand :message
 func (conn *Conn) Cap(subcommmand string, message ...string) {
 	if len(message) == 0 {
 		conn.Raw(CAP + " " + subcommmand)

--- a/client/commands.go
+++ b/client/commands.go
@@ -11,6 +11,7 @@ const (
 	DISCONNECTED = "DISCONNECTED"
 	ACTION       = "ACTION"
 	AWAY         = "AWAY"
+	CAP          = "CAP"
 	CTCP         = "CTCP"
 	CTCPREPLY    = "CTCPREPLY"
 	INVITE       = "INVITE"
@@ -289,3 +290,13 @@ func (conn *Conn) Ping(message string) { conn.Raw(PING + " :" + message) }
 // Pong sends a PONG command to the server.
 //     PONG :message
 func (conn *Conn) Pong(message string) { conn.Raw(PONG + " :" + message) }
+
+// Cap sends a CAP command to the server.
+//     CAP capability
+func (conn *Conn) Cap(subcommmand string, messages ...string) {
+	if len(messages) == 0 {
+		conn.Raw(CAP + " " + subcommmand)
+	} else {
+		conn.Raw(CAP + " " + subcommmand + " :" + strings.Join(messages, " "))
+	}
+}

--- a/client/line.go
+++ b/client/line.go
@@ -107,7 +107,11 @@ func (line *Line) Public() bool {
 // set to CTCP or CTCPREPLY, and the CTCP command prepended to line.Args.
 //
 // ParseLine also parses IRCv3 tags, if received. If a line does not have
-// the tags section, Line.Tags will be nil.
+// the tags section, Line.Tags will be nil. Tags are optional, and will
+// only be included after the correct CAP command.
+//
+// http://ircv3.net/specs/core/capability-negotiation-3.1.html
+// http://ircv3.net/specs/core/message-tags-3.2.html
 func ParseLine(s string) *Line {
 	line := &Line{Raw: s}
 

--- a/client/line.go
+++ b/client/line.go
@@ -119,11 +119,17 @@ func ParseLine(s string) *Line {
 
 		// all tags are escaped, so splitting on ; is right by design
 		for _, tag := range strings.Split(rawTags, ";") {
+			if tag == "" {
+				return nil
+			}
+
 			pair := strings.Split(tagsReplacer.Replace(tag), "=")
-			if len(pair) > 1 {
+			if len(pair) < 2 {
+				line.Tags[tag] = ""
+			} else if len(pair) == 2 {
 				line.Tags[pair[0]] = pair[1]
 			} else {
-				line.Tags[tag] = ""
+				return nil
 			}
 		}
 	}

--- a/client/line_test.go
+++ b/client/line_test.go
@@ -1,12 +1,14 @@
 package client
 
 import (
+	"reflect"
 	"testing"
 	"time"
 )
 
 func TestLineCopy(t *testing.T) {
 	l1 := &Line{
+		Tags:  map[string]string{"foo": "bar", "fizz": "buzz"},
 		Nick:  "nick",
 		Ident: "ident",
 		Host:  "host",
@@ -20,7 +22,8 @@ func TestLineCopy(t *testing.T) {
 	l2 := l1.Copy()
 
 	// Ugly. Couldn't be bothered to bust out reflect and actually think.
-	if l2.Nick != "nick" || l2.Ident != "ident" || l2.Host != "host" ||
+	if l2.Tags == nil || l2.Tags["foo"] != "bar" || l2.Tags["fizz"] != "buzz" ||
+		l2.Nick != "nick" || l2.Ident != "ident" || l2.Host != "host" ||
 		l2.Src != "src" || l2.Cmd != "cmd" || l2.Raw != "raw" ||
 		l2.Args[0] != "arg" || l2.Args[1] != "text" || l2.Time != l1.Time {
 		t.Errorf("Line not copied correctly")
@@ -28,6 +31,7 @@ func TestLineCopy(t *testing.T) {
 	}
 
 	// Now, modify l2 and verify l1 not changed
+	l2.Tags["foo"] = "baz"
 	l2.Nick = l2.Nick[1:]
 	l2.Ident = "foo"
 	l2.Host = ""
@@ -35,7 +39,8 @@ func TestLineCopy(t *testing.T) {
 	l2.Args[1] = "bar"
 	l2.Time = time.Now()
 
-	if l1.Nick != "nick" || l1.Ident != "ident" || l1.Host != "host" ||
+	if l2.Tags == nil || l2.Tags["foo"] != "baz" || l2.Tags["fizz"] != "buzz" ||
+		l1.Nick != "nick" || l1.Ident != "ident" || l1.Host != "host" ||
 		l1.Src != "src" || l1.Cmd != "cmd" || l1.Raw != "raw" ||
 		l1.Args[0] != "arg" || l1.Args[1] != "text" || l1.Time == l2.Time {
 		t.Errorf("Original modified when copy changed")
@@ -85,6 +90,59 @@ func TestLineTarget(t *testing.T) {
 		out := test.in.Target()
 		if out != test.out {
 			t.Errorf("test %d: expected: '%s', got '%s'", i, test.out, out)
+		}
+	}
+}
+
+func TestLineTags(t *testing.T) {
+	tests := []struct {
+		in  string
+		out *Line
+	}{
+		{ // Make sure non-tagged lines work
+			":nick!ident@host.com PRIVMSG me :Hello",
+			&Line{
+				Nick:  "nick",
+				Ident: "ident",
+				Host:  "host.com",
+				Src:   "nick!ident@host.com",
+				Cmd:   PRIVMSG,
+				Raw:   ":nick!ident@host.com PRIVMSG me :Hello",
+				Args:  []string{"me", "Hello"},
+			},
+		},
+		{ // Tags example from the spec
+			"@aaa=bbb;ccc;example.com/ddd=eee :nick!ident@host.com PRIVMSG me :Hello",
+			&Line{
+				Tags:  map[string]string{"aaa": "bbb", "ccc": "", "example.com/ddd": "eee"},
+				Nick:  "nick",
+				Ident: "ident",
+				Host:  "host.com",
+				Src:   "nick!ident@host.com",
+				Cmd:   PRIVMSG,
+				Raw:   "@aaa=bbb;ccc;example.com/ddd=eee :nick!ident@host.com PRIVMSG me :Hello",
+				Args:  []string{"me", "Hello"},
+			},
+		},
+		{ // Test escaped characters
+			"@\\:=\\:;\\s=\\s;\\r=\\r;\\n=\\n :nick!ident@host.com PRIVMSG me :Hello",
+			&Line{
+				Tags:  map[string]string{";": ";", " ": " ", "\r": "\r", "\n": "\n"},
+				Nick:  "nick",
+				Ident: "ident",
+				Host:  "host.com",
+				Src:   "nick!ident@host.com",
+				Cmd:   PRIVMSG,
+				Raw:   "@\\:=\\:;\\s=\\s;\\r=\\r;\\n=\\n :nick!ident@host.com PRIVMSG me :Hello",
+				Args:  []string{"me", "Hello"},
+			},
+		},
+	}
+
+	for i, test := range tests {
+		got := ParseLine(test.in)
+		if !reflect.DeepEqual(got, test.out) {
+			t.Errorf("test %d:\nexpected %#v\ngot %#v", i, test.out, got)
 		}
 	}
 }

--- a/client/line_test.go
+++ b/client/line_test.go
@@ -137,6 +137,8 @@ func TestLineTags(t *testing.T) {
 				Args:  []string{"me", "Hello"},
 			},
 		},
+		{"@a=a; :nick!ident@host.com PRIVMSG me :Hello", nil}, // Bad inputs
+		{"@a=a=a :nick!ident@host.com PRIVMSG me :Hello", nil},
 	}
 
 	for i, test := range tests {

--- a/client/line_test.go
+++ b/client/line_test.go
@@ -137,8 +137,32 @@ func TestLineTags(t *testing.T) {
 				Args:  []string{"me", "Hello"},
 			},
 		},
-		{"@a=a; :nick!ident@host.com PRIVMSG me :Hello", nil}, // Bad inputs
-		{"@a=a=a :nick!ident@host.com PRIVMSG me :Hello", nil},
+		{ // Skip empty tag
+			"@a=a; :nick!ident@host.com PRIVMSG me :Hello",
+			&Line{
+				Tags:  map[string]string{"a": "a"},
+				Nick:  "nick",
+				Ident: "ident",
+				Host:  "host.com",
+				Src:   "nick!ident@host.com",
+				Cmd:   PRIVMSG,
+				Raw:   "@a=a; :nick!ident@host.com PRIVMSG me :Hello",
+				Args:  []string{"me", "Hello"},
+			},
+		},
+		{ // = in tag
+			"@a=a=a; :nick!ident@host.com PRIVMSG me :Hello",
+			&Line{
+				Tags:  map[string]string{"a": "a=a"},
+				Nick:  "nick",
+				Ident: "ident",
+				Host:  "host.com",
+				Src:   "nick!ident@host.com",
+				Cmd:   PRIVMSG,
+				Raw:   "@a=a=a; :nick!ident@host.com PRIVMSG me :Hello",
+				Args:  []string{"me", "Hello"},
+			},
+		},
 	}
 
 	for i, test := range tests {


### PR DESCRIPTION
I needed this for a Twitch bot I'm working on. This adds the CAP command (needed to enable tags), as well as the tag parsing into a `map[string]string`.

If a line doesn't have the tag section, then the map is `nil` as to not have to change other struct initializers in other parts of the code. I didn't add any functions to access the map, as I'm assuming any user would do this themselves, though it would be nice to have some `GetTag()` function that can check if the map is `nil`, but anything that uses the library could probably implement that themselves.

The `Cap` function takes a subcommand, and an optional list of capabilities. I haven't added any extra constants for things like `REQ` or `LS` or similar (should they be added?). 

I also added a few tests for the tagging, and it works in my own tests (connecting to a twitch channel and detecting if someone's a sub or not, etc).

Let me know if you have any suggestions. This is all I personally need, anyway.

http://ircv3.net/specs/core/capability-negotiation-3.1.html
http://ircv3.net/specs/core/message-tags-3.2.html