### PR TITLE
README: add SSLConfig to make connecting work

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Synopsis:
 	package main
 
 	import (
+		"crypto/tls"
 		"fmt"
 
 		irc "github.com/fluffle/goirc/client"
@@ -31,6 +32,7 @@ Synopsis:
 		// Or, create a config and fiddle with it first:
 		cfg := irc.NewConfig("nick")
 		cfg.SSL = true
+		cfg.SSLConfig = &tls.Config{ServerName: "irc.freenode.net"}
 		cfg.Server = "irc.freenode.net:7000"
 		cfg.NewNick = func(n string) string { return n + "^" }
 		c = irc.Client(cfg)


### PR DESCRIPTION
Without an SSLConfig, I get the following error:

```
E0225 08:43:12.384793   28687 connection.go:406] irc.recv(): tls: either ServerName or InsecureSkipVerify must be specified in the tls.Config
```