### PR TITLE
Add logic for verifying PONGS from server

### DIFF
--- a/client/handlers.go
+++ b/client/handlers.go
@@ -16,6 +16,7 @@ var intHandlers = map[string]HandlerFunc{
 	CTCP:     (*Conn).h_CTCP,
 	NICK:     (*Conn).h_NICK,
 	PING:     (*Conn).h_PING,
+	PONG:     (*Conn).h_PONG,
 }
 
 func (conn *Conn) addIntHandlers() {
@@ -29,6 +30,17 @@ func (conn *Conn) addIntHandlers() {
 // Basic ping/pong handler
 func (conn *Conn) h_PING(line *Line) {
 	conn.Pong(line.Args[0])
+}
+
+// Send all pongs to the internal tracker
+func (conn *Conn) h_PONG(line *Line) {
+	// Going by the RFC this makes zero sense, but every IRCd I can find implements
+	// it this way.
+	//
+	// PING :12345
+	// :dreamhack.se.quakenet.org PONG dreamhack.se.quakenet.org :12345
+
+	conn.pongResponses <- line.Text()
 }
 
 // Handler for initial registration with server once tcp connection is made.


### PR DESCRIPTION
This will (optionally) check that the PONGs that we get back contain the message that we sent. 

Most (all?) IRCd servers will return the text of your PING back to you in the PONG. This helps in establishing that you have two-way communication with the IRC server.

Example of successful pings:
```text
I0530 17:50:58.204800   13341 connection.go:458] Current outstanding pings: 0/3
I0530 17:50:58.205028   13341 connection.go:537] -> PING :1496166658204835562
I0530 17:50:58.350480   13341 connection.go:438] <- :rajaniemi.freenode.net PONG rajaniemi.freenode.net :1496166658204835562
I0530 17:50:58.350625   13341 connection.go:477] Processing Pong: 1496166658204835562
I0530 17:52:58.204800   13341 connection.go:458] Current outstanding pings: 0/3
I0530 17:52:58.205012   13341 connection.go:537] -> PING :1496166778204837692
I0530 17:52:58.350588   13341 connection.go:438] <- :rajaniemi.freenode.net PONG rajaniemi.freenode.net :1496166778204837692
I0530 17:52:58.350736   13341 connection.go:477] Processing Pong: 1496166778204837692
I0530 17:54:58.204839   13341 connection.go:458] Current outstanding pings: 0/3
I0530 17:54:58.205076   13341 connection.go:537] -> PING :1496166898204887198
I0530 17:54:58.350742   13341 connection.go:438] <- :rajaniemi.freenode.net PONG rajaniemi.freenode.net :1496166898204887198
I0530 17:54:58.350833   13341 connection.go:477] Processing Pong: 1496166898204887198
```

Example of failed pings:
```text
I0530 18:32:58.204795   13341 connection.go:458] Current outstanding pings: 0/3
I0530 18:32:58.204939   13341 connection.go:537] -> PING :1496169178204836420
I0530 18:34:58.204774   13341 connection.go:458] Current outstanding pings: 1/3
I0530 18:34:58.204893   13341 connection.go:537] -> PING :1496169298204803849
I0530 18:36:58.204881   13341 connection.go:458] Current outstanding pings: 2/3
I0530 18:36:58.205016   13341 connection.go:537] -> PING :1496169418204910266
I0530 18:38:58.204813   13341 connection.go:458] Current outstanding pings: 3/3
I0530 18:38:58.204855   13341 connection.go:571] irc.Close(): Disconnected from server.
E0530 18:38:58.205027   13341 connection.go:430] irc.recv(): read tcp [2600:3c00::f03c:91ff:fe6e:3a69]:56410->[2001:708:40:2001::f5ee:d0de]:6697: use of closed network connection
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fluffle/goirc/100)
<!-- Reviewable:end -->
