### PR TITLE
add nick search by hostmask

### DIFF
--- a/state/mock_tracker.go
+++ b/state/mock_tracker.go
@@ -48,6 +48,16 @@ func (_mr *_MockTrackerRecorder) GetNick(arg0 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetNick", arg0)
 }
 
+func (_m *MockTracker) GetNickByHostmask(host string) *Nick {
+	ret := _m.ctrl.Call(_m, "GetNickByHostmask", host)
+	ret0, _ := ret[0].(*Nick)
+	return ret0
+}
+
+func (_mr *_MockTrackerRecorder) GetNickByHostmask(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetNickByHostmask", arg0)
+}
+
 func (_m *MockTracker) ReNick(old string, neu string) *Nick {
 	ret := _m.ctrl.Call(_m, "ReNick", old, neu)
 	ret0, _ := ret[0].(*Nick)

--- a/state/tracker.go
+++ b/state/tracker.go
@@ -1,6 +1,8 @@
 package state
 
 import (
+	"fmt"
+
 	"github.com/fluffle/goirc/logging"
 
 	"sync"
@@ -11,6 +13,7 @@ type Tracker interface {
 	// Nick methods
 	NewNick(nick string) *Nick
 	GetNick(nick string) *Nick
+	GetNickByHostmask(host string) *Nick
 	ReNick(old, neu string) *Nick
 	DelNick(nick string) *Nick
 	NickInfo(nick, ident, host, name string) *Nick
@@ -96,6 +99,18 @@ func (st *stateTracker) GetNick(n string) *Nick {
 	defer st.mu.Unlock()
 	if nk, ok := st.nicks[n]; ok {
 		return nk.Nick()
+	}
+	return nil
+}
+
+// Returns a nick for the hostmask h, if we're tracking it.
+func (st *stateTracker) GetNickByHostmask(h string) *Nick {
+	st.mu.Lock()
+	defer st.mu.Unlock()
+	for n := range st.nicks {
+		if fmt.Sprintf("%s@%s", st.nicks[n].ident, st.nicks[n].host) == h {
+			return st.nicks[n].Nick()
+		}
 	}
 	return nil
 }

--- a/state/tracker_test.go
+++ b/state/tracker_test.go
@@ -58,6 +58,22 @@ func TestSTGetNick(t *testing.T) {
 	}
 }
 
+func TestSTGetNickByHostmask(t *testing.T) {
+	st := NewTracker("mynick")
+	test1 := st.NewNick("test1")
+	test1 = st.NickInfo("test1", "test", "test", "test")
+
+	if n := st.GetNickByHostmask("test@test"); !test1.Equals(n) {
+		t.Errorf("Incorrect nick returned by GetNickByHostmask.")
+	}
+	if n := st.GetNickByHostmask("test2@test"); n != nil {
+		t.Errorf("Nick unexpectedly returned by GetNickByHostmask.")
+	}
+	if len(st.nicks) != 2 {
+		t.Errorf("Nick list changed size during GetNickByHostmask.")
+	}
+}
+
 func TestSTReNick(t *testing.T) {
 	st := NewTracker("mynick")
 	test1 := st.NewNick("test1")


### PR DESCRIPTION
To make sure that I am talking to the same person, I wanted to get a nick by hostmask.

Since it is adding a new method to the Tracker interface it will brake compatibility with people who created their own stateTracker, so I don't know if this pull request is welcome?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fluffle/goirc/104)
<!-- Reviewable:end -->
