### PR TITLE
Add SASL authentication support

### DIFF
--- a/client/commands.go
+++ b/client/commands.go
@@ -10,6 +10,7 @@ const (
 	CONNECTED    = "CONNECTED"
 	DISCONNECTED = "DISCONNECTED"
 	ACTION       = "ACTION"
+	AUTHENTICATE = "AUTHENTICATE"
 	AWAY         = "AWAY"
 	CAP          = "CAP"
 	CTCP         = "CTCP"
@@ -321,4 +322,9 @@ func (conn *Conn) Cap(subcommmand string, capabilities ...string) {
 			conn.Raw(cmdPrefix + args)
 		}
 	}
+}
+
+// Authenticate send an AUTHENTICATE command to the server.
+func (conn *Conn) Authenticate(message string) {
+	conn.Raw(AUTHENTICATE + " " + message)
 }

--- a/client/sasl_test.go
+++ b/client/sasl_test.go
@@ -1,0 +1,103 @@
+package client
+
+import (
+	"github.com/emersion/go-sasl"
+	"testing"
+)
+
+func TestSaslPlainSuccessWorkflow(t *testing.T) {
+	c, s := setUp(t)
+	defer s.tearDown()
+
+	c.Config().Sasl = sasl.NewPlainClient("", "example", "password")
+	c.Config().EnableCapabilityNegotiation = true
+
+	c.h_REGISTER(&Line{Cmd: REGISTER})
+	s.nc.Expect("CAP LS")
+	s.nc.Expect("NICK test")
+	s.nc.Expect("USER test 12 * :Testing IRC")
+	s.nc.Send("CAP * LS :sasl foobar")
+	s.nc.Expect("CAP REQ :sasl")
+	s.nc.Send("CAP * ACK :sasl")
+	s.nc.Expect("AUTHENTICATE PLAIN")
+	s.nc.Send("AUTHENTICATE +")
+	s.nc.Expect("AUTHENTICATE AGV4YW1wbGUAcGFzc3dvcmQ=")
+	s.nc.Send("904 test :SASL authentication successful")
+	s.nc.Expect("CAP END")
+}
+
+func TestSaslPlainWrongPassword(t *testing.T) {
+	c, s := setUp(t)
+	defer s.tearDown()
+
+	c.Config().Sasl = sasl.NewPlainClient("", "example", "password")
+	c.Config().EnableCapabilityNegotiation = true
+
+	c.h_REGISTER(&Line{Cmd: REGISTER})
+	s.nc.Expect("CAP LS")
+	s.nc.Expect("NICK test")
+	s.nc.Expect("USER test 12 * :Testing IRC")
+	s.nc.Send("CAP * LS :sasl foobar")
+	s.nc.Expect("CAP REQ :sasl")
+	s.nc.Send("CAP * ACK :sasl")
+	s.nc.Expect("AUTHENTICATE PLAIN")
+	s.nc.Send("AUTHENTICATE +")
+	s.nc.Expect("AUTHENTICATE AGV4YW1wbGUAcGFzc3dvcmQ=")
+	s.nc.Send("904 test :SASL authentication failed")
+	s.nc.Expect("CAP END")
+}
+
+func TestSaslExternalSuccessWorkflow(t *testing.T) {
+	c, s := setUp(t)
+	defer s.tearDown()
+
+	c.Config().Sasl = sasl.NewExternalClient("")
+	c.Config().EnableCapabilityNegotiation = true
+
+	c.h_REGISTER(&Line{Cmd: REGISTER})
+	s.nc.Expect("CAP LS")
+	s.nc.Expect("NICK test")
+	s.nc.Expect("USER test 12 * :Testing IRC")
+	s.nc.Send("CAP * LS :sasl foobar")
+	s.nc.Expect("CAP REQ :sasl")
+	s.nc.Send("CAP * ACK :sasl")
+	s.nc.Expect("AUTHENTICATE EXTERNAL")
+	s.nc.Send("AUTHENTICATE +")
+	s.nc.Expect("AUTHENTICATE +")
+	s.nc.Send("904 test :SASL authentication successful")
+	s.nc.Expect("CAP END")
+}
+
+func TestSaslNoSaslCap(t *testing.T) {
+	c, s := setUp(t)
+	defer s.tearDown()
+
+	c.Config().Sasl = sasl.NewPlainClient("", "example", "password")
+	c.Config().EnableCapabilityNegotiation = true
+
+	c.h_REGISTER(&Line{Cmd: REGISTER})
+	s.nc.Expect("CAP LS")
+	s.nc.Expect("NICK test")
+	s.nc.Expect("USER test 12 * :Testing IRC")
+	s.nc.Send("CAP * LS :foobar")
+	s.nc.Expect("CAP END")
+}
+
+func TestSaslUnsupportedMechanism(t *testing.T) {
+	c, s := setUp(t)
+	defer s.tearDown()
+
+	c.Config().Sasl = sasl.NewPlainClient("", "example", "password")
+	c.Config().EnableCapabilityNegotiation = true
+
+	c.h_REGISTER(&Line{Cmd: REGISTER})
+	s.nc.Expect("CAP LS")
+	s.nc.Expect("NICK test")
+	s.nc.Expect("USER test 12 * :Testing IRC")
+	s.nc.Send("CAP * LS :sasl foobar")
+	s.nc.Expect("CAP REQ :sasl")
+	s.nc.Send("CAP * ACK :sasl")
+	s.nc.Expect("AUTHENTICATE PLAIN")
+	s.nc.Send("908 test external :are available SASL mechanisms")
+	s.nc.Expect("CAP END")
+}

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,7 @@
 module github.com/fluffle/goirc
 
 require (
+	github.com/emersion/go-sasl v0.0.0-20220912192320-0145f2c60ead
 	github.com/golang/mock v1.5.0
 	golang.org/x/net v0.0.0-20210119194325-5f4716e94777
 )

--- a/go.sum
+++ b/go.sum
@@ -1,9 +1,10 @@
+github.com/emersion/go-sasl v0.0.0-20220912192320-0145f2c60ead h1:fI1Jck0vUrXT8bnphprS1EoVRe2Q5CKCX8iDlpqjQ/Y=
+github.com/emersion/go-sasl v0.0.0-20220912192320-0145f2c60ead/go.mod h1:iL2twTeMvZnrg54ZoPDNfJaJaqy0xIQFuBdrLsmspwQ=
 github.com/golang/mock v1.5.0 h1:jlYHihg//f7RRwuPfptm04yp4s7O6Kw8EZiVYIGcH0g=
 github.com/golang/mock v1.5.0/go.mod h1:CWnOUgYIOo4TcNZ0wHX3YZCqsaM1I1Jvs6v3mP3KVu8=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/mod v0.3.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
-golang.org/x/net v0.0.0-20180926154720-4dfa2610cdf3/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20210119194325-5f4716e94777 h1:003p0dJM77cxMSyCPFphvZf/Y5/NXf5fzg6ufd1/Oew=


### PR DESCRIPTION
This hacks together support for IRCv3.1 SASL. Currently only SASL PLAIN
is supported, but it's implemented in a way that adding support for
other types should not require too many changes to the current code.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fluffle/goirc/117)
<!-- Reviewable:end -->
